### PR TITLE
Improve upload preview scrolling and file parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ Run frontend tests with:
 npm test
 ```
 
+### Document upload preview
+
+The home page now supports uploading PDF or TXT documents from the right-hand panel. After a successful upload, the file picker disappears and is replaced with a scrollable preview of the extracted text. The preview panel is height-limited so long documents stay within the layout and scroll vertically instead of expanding the card. When a PDF contains multiple pages, pagination controls let you move between pages while keeping the text panel scrollable for long content. Unsupported file types are rejected with a clear validation message.
+
 Run backend tests with:
 
 ```bash

--- a/src/__tests__/HomePage.test.tsx
+++ b/src/__tests__/HomePage.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect } from 'vitest';
+import HomePage from '../pages/HomePage';
+
+describe('HomePage upload area', () => {
+  it('uploads a txt file and shows its content', async () => {
+    render(<HomePage />);
+
+    const uploadInput = screen.getByLabelText(/upload a pdf or txt file/i);
+    const file = new File(['Hello from the test file'], 'example.txt', { type: 'text/plain' });
+
+    await userEvent.upload(uploadInput, file, { applyAccept: false });
+
+    expect(await screen.findByText(/Hello from the test file/i)).toBeInTheDocument();
+    expect(screen.queryByText(/upload a document/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/Page 1 of 1/i)).toBeInTheDocument();
+
+    const scrollArea = screen.getByTestId('uploaded-text-viewer');
+    expect(scrollArea).toHaveClass('overflow-y-auto');
+    expect(scrollArea).toHaveClass('h-full');
+    expect(scrollArea.parentElement).toHaveClass('h-80');
+  });
+
+  it('prevents unsupported file types', async () => {
+    render(<HomePage />);
+
+    const uploadInput = screen.getByLabelText(/upload a pdf or txt file/i);
+    const file = new File(['binary'], 'image.png', { type: 'image/png' });
+
+    await userEvent.upload(uploadInput, file, { applyAccept: false });
+    expect(await screen.findByText(/only pdf and txt files are supported/i)).toBeInTheDocument();
+    expect(screen.getByText(/upload a document/i)).toBeInTheDocument();
+  });
+
+  it('navigates between pdf pages when multiple pages exist', async () => {
+    render(<HomePage />);
+
+    const uploadInput = screen.getByLabelText(/upload a pdf or txt file/i);
+    const pdfContent = `%PDF-1.4\n1 0 obj\n<< /Type /Page >>\nstream\nBT (First page text) ET\nendstream\nendobj\n2 0 obj\n<< /Type /Page >>\nstream\nBT (Second page text) ET\nendstream\nendobj\n`;
+    const file = new File([pdfContent], 'document.pdf', { type: 'application/pdf' });
+
+    await userEvent.upload(uploadInput, file);
+
+    expect(await screen.findByText(/First page text/)).toBeInTheDocument();
+    expect(screen.getByText(/Page 1 of 2/)).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /next page/i }));
+    expect(await screen.findByText(/Second page text/)).toBeInTheDocument();
+    expect(screen.getByText(/Page 2 of 2/)).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /previous page/i }));
+    expect(await screen.findByText(/First page text/)).toBeInTheDocument();
+    expect(screen.getByText(/Page 1 of 2/)).toBeInTheDocument();
+  });
+});

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,8 +1,12 @@
-import { useState, FormEvent, KeyboardEvent, useRef, useEffect } from "react";
+import { useState, FormEvent, KeyboardEvent, useRef, useEffect, ChangeEvent } from "react";
 
 const HomePage = () => {
   const [text, setText] = useState("");
   const [submittedTexts, setSubmittedTexts] = useState<Array<{ text: string; timestamp: string }>>([]);
+  const [uploadedPages, setUploadedPages] = useState<string[]>([]);
+  const [currentPage, setCurrentPage] = useState(0);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const [uploadedFileName, setUploadedFileName] = useState("");
   const historyRef = useRef<HTMLDivElement | null>(null);
   const textAreaRef = useRef<HTMLTextAreaElement | null>(null);
 
@@ -36,6 +40,130 @@ const HomePage = () => {
     e.preventDefault();
     submitText();
   };
+
+  const decodePdfString = (input: string) =>
+    input
+      .replace(/\\\(/g, "(")
+      .replace(/\\\)/g, ")")
+      .replace(/\\n/g, "\n")
+      .replace(/\\r/g, "\r")
+      .replace(/\\t/g, "\t")
+      .replace(/\\f/g, "\f")
+      .replace(/\\b/g, "\b")
+      .replace(/\\\\/g, "\\");
+
+  const readFileText = (file: File) =>
+    new Promise<string>((resolve, reject) => {
+      if (typeof FileReader === "undefined") {
+        reject(new Error("FileReader is not supported in this environment."));
+        return;
+      }
+
+      if (typeof file.text === "function") {
+        file
+          .text()
+          .then((content) => resolve(content))
+          .catch(reject);
+        return;
+      }
+
+      const reader = new FileReader();
+      reader.onload = () => resolve((reader.result as string) ?? "");
+      reader.onerror = () => reject(reader.error ?? new Error("Failed to read file"));
+      reader.readAsText(file);
+    });
+
+  const readFileArrayBuffer = (file: File) =>
+    new Promise<ArrayBuffer>((resolve, reject) => {
+      if (typeof FileReader === "undefined") {
+        reject(new Error("FileReader is not supported in this environment."));
+        return;
+      }
+
+      if (typeof file.arrayBuffer === "function") {
+        file
+          .arrayBuffer()
+          .then((content) => resolve(content))
+          .catch(reject);
+        return;
+      }
+
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result as ArrayBuffer);
+      reader.onerror = () => reject(reader.error ?? new Error("Failed to read file"));
+      reader.readAsArrayBuffer(file);
+    });
+
+  const extractPdfPages = async (file: File) => {
+    const arrayBuffer = await readFileArrayBuffer(file);
+    const decodedPdf = new TextDecoder("latin1").decode(arrayBuffer);
+    const rawPages = decodedPdf.split(/\/(?:Type)\s*\/Page[^s]/g).slice(1);
+
+    const parsedPages = rawPages
+      .map((page) => {
+        const textMatches = [...page.matchAll(/\(([^()]*(?:\\\(|\\\)[^()]*)*)\)/g)];
+        const pageText = textMatches.map((match) => decodePdfString(match[1])).join(" ").trim();
+        return pageText;
+      })
+      .filter((pageText) => pageText.length > 0);
+
+    return parsedPages.length > 0 ? parsedPages : [decodedPdf];
+  };
+
+  const handleFileChange = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    const extension = file.name.toLowerCase();
+    const isPdf = file.type === "application/pdf" || extension.endsWith(".pdf");
+    const isText = file.type === "text/plain" || extension.endsWith(".txt");
+
+
+    if (!isPdf && !isText) {
+      setUploadError("Only PDF and TXT files are supported.");
+      setUploadedPages([]);
+      setUploadedFileName("");
+      event.target.value = "";
+      return;
+    }
+
+    try {
+      setUploadError(null);
+      setUploadedFileName(file.name);
+
+      if (isPdf) {
+        const pages = await extractPdfPages(file);
+        setUploadedPages(pages);
+        setCurrentPage(0);
+      } else {
+        const fileText = await readFileText(file);
+        setUploadedPages([fileText]);
+        setCurrentPage(0);
+      }
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error("Failed to read file", error);
+      setUploadError("Something went wrong while reading the file. Please try again.");
+    }
+  };
+
+  const goToPreviousPage = () => {
+    setCurrentPage((prev) => Math.max(prev - 1, 0));
+  };
+
+  const goToNextPage = () => {
+    setCurrentPage((prev) => Math.min(prev + 1, uploadedPages.length - 1));
+  };
+
+  const resetUpload = () => {
+    setUploadedPages([]);
+    setCurrentPage(0);
+    setUploadedFileName("");
+    setUploadError(null);
+  };
+
+  const hasUploadedFile = uploadedPages.length > 0;
+
   return (
     <section className="space-y-6">
       <h1 className="text-3xl font-bold tracking-tight text-slate-900 dark:text-white">Welcome to MyApp</h1>
@@ -103,25 +231,95 @@ const HomePage = () => {
             </div>
           </form>
         </div>
-        <div className="flex min-h-[28rem] items-center justify-center rounded-3xl border-2 border-dashed border-slate-300 bg-slate-100/60 p-6 text-slate-500 dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-400">
-          <div className="flex flex-col items-center gap-3 text-center">
-            <div className="flex h-16 w-16 items-center justify-center rounded-full bg-white shadow-sm dark:bg-slate-800">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="1.5"
-                className="h-8 w-8"
-                aria-hidden="true"
-              >
-                <path d="M4 16.5V17a3 3 0 0 0 3 3h10a3 3 0 0 0 3-3v-.5" />
-                <path d="m8 12 4-4 4 4" />
-                <path d="M12 16V8" />
-              </svg>
+        <div className="flex min-h-[28rem] flex-col gap-4 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm transition hover:-translate-y-1 hover:shadow-lg dark:border-slate-700 dark:bg-slate-900 dark:shadow-glow">
+          {!hasUploadedFile ? (
+            <div className="flex flex-1 flex-col items-center justify-center gap-4 text-center text-slate-600 dark:text-slate-300">
+              <div className="flex h-16 w-16 items-center justify-center rounded-full bg-slate-100 shadow-sm dark:bg-slate-800">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  className="h-8 w-8"
+                  aria-hidden="true"
+                >
+                  <path d="M4 16.5V17a3 3 0 0 0 3 3h10a3 3 0 0 0 3-3v-.5" />
+                  <path d="m8 12 4-4 4 4" />
+                  <path d="M12 16V8" />
+                </svg>
+              </div>
+              <div className="space-y-2">
+                <p className="text-lg font-semibold text-slate-900 dark:text-white">Upload a document</p>
+                <p className="text-sm text-slate-600 dark:text-slate-400">PDF and TXT files are supported.</p>
+              </div>
+              <label className="inline-flex cursor-pointer items-center justify-center rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2">
+                Upload file
+                <input
+                  aria-label="Upload a PDF or TXT file"
+                  className="sr-only"
+                  type="file"
+                  accept=".pdf,.txt,application/pdf,text/plain"
+                  onChange={handleFileChange}
+                />
+              </label>
+              {uploadError && <p className="text-sm text-red-600">{uploadError}</p>}
             </div>
-            <p className="text-sm">File upload coming soon.</p>
-          </div>
+          ) : (
+            <div className="flex h-full flex-col gap-4">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <p className="text-sm font-semibold text-slate-900 dark:text-white">{uploadedFileName}</p>
+                  <p className="text-xs text-slate-500 dark:text-slate-400">
+                    Page {currentPage + 1} of {uploadedPages.length}
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={resetUpload}
+                  className="rounded-full border border-slate-300 px-3 py-1 text-xs font-medium text-slate-700 transition hover:bg-slate-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:border-slate-600 dark:text-slate-200 dark:hover:bg-slate-800"
+                >
+                  Upload another file
+                </button>
+              </div>
+              <div className="h-80 overflow-hidden rounded-xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-800/70">
+                <div
+                  data-testid="uploaded-text-viewer"
+                  className="h-full overflow-y-auto rounded-lg bg-white p-4 shadow-inner dark:bg-slate-900/60"
+                >
+                  <pre className="whitespace-pre-wrap break-words text-sm text-slate-800 dark:text-slate-100">
+                    {uploadedPages[currentPage] || ""}
+                  </pre>
+                </div>
+              </div>
+              {uploadError && <p className="text-sm text-red-600">{uploadError}</p>}
+              {uploadedPages.length > 1 && (
+                <div className="flex items-center justify-between gap-3">
+                  <div className="text-xs font-medium text-slate-600 dark:text-slate-300">
+                    Navigate pages
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={goToPreviousPage}
+                      disabled={currentPage === 0}
+                      className="rounded-full border border-slate-300 px-3 py-1 text-xs font-semibold text-slate-700 transition hover:bg-slate-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-600 dark:text-slate-200 dark:hover:bg-slate-800"
+                    >
+                      Previous page
+                    </button>
+                    <button
+                      type="button"
+                      onClick={goToNextPage}
+                      disabled={currentPage === uploadedPages.length - 1}
+                      className="rounded-full border border-slate-300 px-3 py-1 text-xs font-semibold text-slate-700 transition hover:bg-slate-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-600 dark:text-slate-200 dark:hover:bg-slate-800"
+                    >
+                      Next page
+                    </button>
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- add a fixed-height, scrollable upload preview area and data-testid for easier verification
- harden file reading to use FileReader fallbacks for PDF/TXT processing in jsdom environments
- expand documentation and tests to cover scrolling expectations and unsupported file handling

## Testing
- CI=1 VITEST_MAX_THREADS=1 VITEST_MIN_THREADS=1 npx vitest run --reporter=basic


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925827c17e4832488a1044b272d443a)